### PR TITLE
Show logs on the frontend using SSE

### DIFF
--- a/src/backend/src/control_process/api/api.py
+++ b/src/backend/src/control_process/api/api.py
@@ -7,7 +7,7 @@ from control_process.state_management import StateManagement
 from control_process.state_management_recording_management_only import (
     StateManagementRecordingManagementOnly,
 )
-from control_process.api.sse import register_status_sse
+from control_process.api.sse import register_logs_sse, register_status_sse
 from control_process.api.transcode import register_transcode_routes
 from flask import Flask, jsonify, request, send_from_directory
 from flask_cors import CORS
@@ -30,6 +30,7 @@ def run_api_gateway(
     CORS(app)
 
     register_status_sse(app, state_management)
+    register_logs_sse(app)
     register_transcode_routes(app, state_management)
 
     @app.get("/api/generate_204")

--- a/src/backend/src/control_process/api/sse.py
+++ b/src/backend/src/control_process/api/sse.py
@@ -93,3 +93,57 @@ def register_status_sse(
                 "X-Accel-Buffering": "no",
             },
         )
+
+
+class _LogStreamHandler(logging.Handler):
+    """Logging handler that forwards log records to an SSE announcer."""
+
+    def __init__(self, announcer: _MessageAnnouncer):
+        super().__init__()
+        self._announcer = announcer
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            msg = self.format(record)
+            payload = json.dumps(
+                {
+                    "level": record.levelname,
+                    "name": record.name,
+                    "message": msg,
+                    "created": record.created,
+                }
+            )
+            self._announcer.announce(_format_sse(payload, event="log"))
+        except Exception:
+            self.handleError(record)
+
+
+def register_logs_sse(app) -> None:
+    """Register GET /api/logs (SSE) and attach a logging handler to stream log records."""
+    log_announcer = _MessageAnnouncer()
+    handler = _LogStreamHandler(log_announcer)
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    )
+    logging.getLogger().addHandler(handler)
+
+    @app.get("/api/logs")
+    def logs_stream():
+        def stream():
+            messages = log_announcer.listen()
+            try:
+                while True:
+                    yield messages.get()
+            finally:
+                log_announcer.remove(messages)
+
+        return Response(
+            stream_with_context(stream()),
+            mimetype="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "Content-Type": "text/event-stream",
+                "X-Accel-Buffering": "no",
+            },
+        )

--- a/src/react-app/src/App.tsx
+++ b/src/react-app/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom'
 
 import ControlPage from './pages/control'
 
+import LogsPage from '@/pages/logs'
 import RecordingsPage from '@/pages/recordings'
 
 function App() {
@@ -9,6 +10,7 @@ function App() {
     <Routes>
       <Route element={<ControlPage />} path="/" />
       <Route element={<RecordingsPage />} path="/recordings" />
+      <Route element={<LogsPage />} path="/logs" />
       <Route element={<Navigate replace to="/" />} path="*" />
     </Routes>
   )

--- a/src/react-app/src/components/navbar.tsx
+++ b/src/react-app/src/components/navbar.tsx
@@ -56,6 +56,19 @@ export const Navbar = () => {
               <Trans>Recordings</Trans>
             </NavLink>
           </NavbarItem>
+          <NavbarItem>
+            <NavLink
+              className={({ isActive }: { isActive: boolean }) =>
+                clsx(
+                  linkStyles({ color: 'foreground' }),
+                  isActive ? 'font-bold' : 'text-gray-500'
+                )
+              }
+              to={'/logs'}
+            >
+              <Trans>Logs</Trans>
+            </NavLink>
+          </NavbarItem>
         </div>
       </NavbarContent>
       <NavbarContent justify="end">

--- a/src/react-app/src/network/api.ts
+++ b/src/react-app/src/network/api.ts
@@ -42,6 +42,13 @@ export type RecordingListResponse = {
   recordings: Recording[]
 }
 
+export type LogEntry = {
+  level: string
+  name: string
+  message: string
+  created: number
+}
+
 export type ApiResponse<T = Record<string, unknown>> = T
 
 export class ApiError extends Error {
@@ -95,6 +102,11 @@ export class ApiClient {
   /** URL for the status SSE stream (GET /api/status). */
   getStatusStreamUrl(): string {
     return `${this.baseUrl}/api/status`
+  }
+
+  /** URL for the logs SSE stream (GET /api/logs). */
+  getLogsStreamUrl(): string {
+    return `${this.baseUrl}/api/logs`
   }
 
   /** URL for discovery probe (GET /api/generate_204). */

--- a/src/react-app/src/network/rocamProvider.tsx
+++ b/src/react-app/src/network/rocamProvider.tsx
@@ -6,12 +6,14 @@ import {
   type ReactNode,
 } from 'react'
 
-import { ApiClient, type StatusResponse } from './api'
+import { ApiClient, type LogEntry, type StatusResponse } from './api'
 
 interface RocamContextType {
   apiClient: ApiClient | null
   statusPollingError: Error | null
   status: StatusResponse | null
+  logs: LogEntry[]
+  logsError: Error | null
 }
 
 const RocamContext = createContext<RocamContextType | undefined>(undefined)
@@ -20,10 +22,14 @@ interface RocamProviderProps {
   children: ReactNode
 }
 
+const MAX_LOG_ENTRIES = 1000
+
 export function RocamProvider({ children }: RocamProviderProps) {
   const [apiClient, setApiClient] = useState<ApiClient | null>(null)
   const [error, setError] = useState<Error | null>(null)
   const [status, setStatus] = useState<StatusResponse | null>(null)
+  const [logs, setLogs] = useState<LogEntry[]>([])
+  const [logsError, setLogsError] = useState<Error | null>(null)
 
   // Initialize API client
   useEffect(() => {
@@ -78,10 +84,42 @@ export function RocamProvider({ children }: RocamProviderProps) {
     }
   }, [apiClient])
 
+  // Subscribe to logs SSE stream
+  useEffect(() => {
+    if (!apiClient) return
+
+    const url = apiClient.getLogsStreamUrl()
+    const es = new EventSource(url)
+
+    es.addEventListener('log', (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data) as LogEntry
+        setLogs((prev) => {
+          const next = [...prev, data]
+          if (next.length > MAX_LOG_ENTRIES) return next.slice(-MAX_LOG_ENTRIES)
+          return next
+        })
+        setLogsError(null)
+      } catch {
+        // ignore malformed messages
+      }
+    })
+
+    es.onerror = () => {
+      setLogsError(new Error('Logs stream connection error'))
+    }
+
+    return () => {
+      es.close()
+    }
+  }, [apiClient])
+
   const value: RocamContextType = {
     apiClient,
     statusPollingError: error,
     status,
+    logs,
+    logsError,
   }
 
   return <RocamContext.Provider value={value}>{children}</RocamContext.Provider>

--- a/src/react-app/src/pages/logs.tsx
+++ b/src/react-app/src/pages/logs.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react'
+import { Card, CardBody } from '@heroui/card'
+import { Spinner } from '@heroui/spinner'
+import { useLingui } from '@lingui/react/macro'
+
+import DefaultLayout from '@/layouts/default'
+import { useRocam } from '@/network/rocamProvider'
+
+function levelColor(level: string): string {
+  switch (level) {
+    case 'DEBUG':
+      return 'text-gray-500'
+    case 'INFO':
+      return 'text-foreground'
+    case 'WARNING':
+      return 'text-amber-600'
+    case 'ERROR':
+    case 'CRITICAL':
+      return 'text-red-600'
+    default:
+      return 'text-foreground'
+  }
+}
+
+export default function LogsPage() {
+  const { t } = useLingui()
+  const { logs, logsError } = useRocam()
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [logs.length])
+
+  return (
+    <DefaultLayout className="flex flex-col">
+      <div className="flex flex-col gap-4 m-4 mt-0 min-w-0 w-full flex-1">
+        <Card radius="sm" className="flex-1 min-h-0 flex flex-col">
+          <CardBody className="flex-1 overflow-hidden flex flex-col p-0">
+            {logsError && (
+              <div className="px-4 py-2 bg-danger-100 text-danger-700 text-sm">
+                {logsError.message}
+              </div>
+            )}
+            <div className="flex-1 overflow-auto p-4 font-mono text-sm">
+              {logs.length === 0 && !logsError && (
+                <div className="flex items-center justify-center h-full text-default-500">
+                  <Spinner size="lg" label={t`Connecting to logs stream...`} />
+                </div>
+              )}
+              {logs.map((entry, i) => (
+                <div
+                  key={`${entry.created}-${i}`}
+                  className={`py-0.5 break-all ${levelColor(entry.level)}`}
+                >
+                  {entry.message}
+                </div>
+              ))}
+              <div ref={bottomRef} />
+            </div>
+          </CardBody>
+        </Card>
+      </div>
+    </DefaultLayout>
+  )
+}


### PR DESCRIPTION
Implements #289

## Summary
- **Backend**: Added `GET /api/logs` SSE endpoint. A custom logging handler forwards log records to an SSE announcer; each event is sent with `event: log` and JSON payload `{ level, name, message, created }`.
- **Frontend**: Subscribed to the logs stream in `RocamProvider` (same pattern as status SSE). Added `LogEntry` type and `getLogsStreamUrl()`, capping in-memory log buffer at 1000 entries.
- **UI**: New **Logs** page at `/logs` with a scrollable, level-colored log view and a navbar link.

Follows the same SSE approach as the status stream (PR #290 / issue #288).

Made with [Cursor](https://cursor.com)