### PR TITLE
Add Reflection and Traceability Report

### DIFF
--- a/docs/ReflectAndTrace/ReflectAndTrace.tex
+++ b/docs/ReflectAndTrace/ReflectAndTrace.tex
@@ -48,64 +48,64 @@ annotations, as well as from peer review. All items have been addressed in
 commit \texttt{30cd72c} (PR~\#365).
 
 \begin{longtable}{p{0.08\textwidth} p{0.20\textwidth} p{0.32\textwidth} p{0.32\textwidth}}
-\toprule
-\textbf{Item} & \textbf{Source} & \textbf{Feedback} & \textbf{Response} \\
-\midrule
-\endhead
-HA-1 & TA Tanya & Placeholder ``Date1/Date2'' remained in the Hazard Analysis document & Replaced with actual revision dates \\
-\midrule
-HA-2 & TA Tanya & Typo: ``a existing'' & Corrected to ``an existing'' \\
-\midrule
-HA-3 & TA Tanya & Typo: ``moodule'' & Corrected to ``module'' \\
-\midrule
-HA-4 & TA Tanya & Typo: ``a off the shelf'' & Corrected to ``an off-the-shelf'' \\
-\midrule
-HA-5 & TA Tanya & Typo: ``accerlerated'' & Corrected to ``accelerated'' \\
-\midrule
-HA-6 & TA Tanya & Typo: ``excesses'' & Corrected to ``exceeds'' \\
-\midrule
-HA-7 & TA Tanya & Inconsistent phrasing: ``general of the shelf'' & Corrected to ``Off-the-Shelf'' with consistent capitalization \\
-\midrule
-HA-8 & TA Tanya & Safety requirements SR1--SR3 lacked sufficient detail & Expanded SR1--SR3 with specific conditions, thresholds, and verification methods \\
-\midrule
-HA-9 & Supervisor & No emergency stop mechanism defined & Added SR4 (Emergency Stop) requirement specifying hardware and software stop triggers \\
-\midrule
-HA-10 & TA Tanya & No traceability between HA and SRS & Added a full HA~$\leftrightarrow$~SRS traceability table mapping each hazard to corresponding safety requirements \\
-\midrule
-SRS-1 & TA Tanya & Typo: ``equipments'' & Corrected to ``equipment'' \\
-\midrule
-SRS-2 & TA Tanya & Typo: ``Through out'' & Corrected to ``Throughout'' \\
-\midrule
-SRS-3 & TA Tanya & Formatting: ``500CAD'' missing space & Corrected to ``500 CAD'' \\
-\midrule
-SRS-4 & TA Tanya & Duplicate identifier AR-1 used for two different requirements & Renamed the second instance to ACR-1 to eliminate ambiguity \\
-\midrule
-SRS-5 & TA Tanya & Safety requirements section lacked HA traceability & Added Hazard Analysis trace references to all safety requirements in the SRS \\
-\bottomrule
+  \toprule
+  \textbf{Item} & \textbf{Source} & \textbf{Feedback}                                                    & \textbf{Response}                                                                                                 \\
+  \midrule
+  \endhead
+  HA-1          & TA Tanya        & Placeholder ``Date1/Date2'' remained in the Hazard Analysis document & Replaced with actual revision dates                                                                               \\
+  \midrule
+  HA-2          & TA Tanya        & Typo: ``a existing''                                                 & Corrected to ``an existing''                                                                                      \\
+  \midrule
+  HA-3          & TA Tanya        & Typo: ``moodule''                                                    & Corrected to ``module''                                                                                           \\
+  \midrule
+  HA-4          & TA Tanya        & Typo: ``a off the shelf''                                            & Corrected to ``an off-the-shelf''                                                                                 \\
+  \midrule
+  HA-5          & TA Tanya        & Typo: ``accerlerated''                                               & Corrected to ``accelerated''                                                                                      \\
+  \midrule
+  HA-6          & TA Tanya        & Typo: ``excesses''                                                   & Corrected to ``exceeds''                                                                                          \\
+  \midrule
+  HA-7          & TA Tanya        & Inconsistent phrasing: ``general of the shelf''                      & Corrected to ``Off-the-Shelf'' with consistent capitalization                                                     \\
+  \midrule
+  HA-8          & TA Tanya        & Safety requirements SR1--SR3 lacked sufficient detail                & Expanded SR1--SR3 with specific conditions, thresholds, and verification methods                                  \\
+  \midrule
+  HA-9          & Supervisor      & No emergency stop mechanism defined                                  & Added SR4 (Emergency Stop) requirement specifying hardware and software stop triggers                             \\
+  \midrule
+  HA-10         & TA Tanya        & No traceability between HA and SRS                                   & Added a full HA~$\leftrightarrow$~SRS traceability table mapping each hazard to corresponding safety requirements \\
+  \midrule
+  SRS-1         & TA Tanya        & Typo: ``equipments''                                                 & Corrected to ``equipment''                                                                                        \\
+  \midrule
+  SRS-2         & TA Tanya        & Typo: ``Through out''                                                & Corrected to ``Throughout''                                                                                       \\
+  \midrule
+  SRS-3         & TA Tanya        & Formatting: ``500CAD'' missing space                                 & Corrected to ``500 CAD''                                                                                          \\
+  \midrule
+  SRS-4         & TA Tanya        & Duplicate identifier AR-1 used for two different requirements        & Renamed the second instance to ACR-1 to eliminate ambiguity                                                       \\
+  \midrule
+  SRS-5         & TA Tanya        & Safety requirements section lacked HA traceability                   & Added Hazard Analysis trace references to all safety requirements in the SRS                                      \\
+  \bottomrule
 \end{longtable}
 
 \subsection{Design and Design Documentation}
 
-Feedback was received from Issues~\#164 and~\#240. All items have been addressed
-in commit \texttt{30cd72c} (PR~\#365).
+Feedback was received from Issues~\#164 and~\#240. All items have been
+addressed in commit \texttt{30cd72c} (PR~\#365).
 
 \begin{longtable}{p{0.08\textwidth} p{0.20\textwidth} p{0.32\textwidth} p{0.32\textwidth}}
-\toprule
-\textbf{Item} & \textbf{Source} & \textbf{Feedback} & \textbf{Response} \\
-\midrule
-\endhead
-MG-1 & TA (Issue~\#164) & Typo: ``relys'' & Corrected to ``relies on'' \\
-\midrule
-MG-2 & TA (Issue~\#164) & Typo: ``Stablize'' & Corrected to ``Stabilize'' \\
-\midrule
-MG-3 & TA (Issue~\#164) & Residual \texttt{\textbackslash wss\{\}} template comments remained in the Module Guide & Removed all \texttt{\textbackslash wss\{\}} comments from the MG \\
-\midrule
-MIS-1 & TA (Issue~\#240) & Incorrect year: ``Jan 2025'' should be ``Jan 2026'' & Corrected to ``Jan 2026'' \\
-\midrule
-MIS-2 & TA (Issue~\#240) & Typo: ``presistent'' & Corrected to ``persistent'' \\
-\midrule
-MIS-3 & TA (Issue~\#240) & Residual \texttt{\textbackslash wss\{\}} template comments remained in the MIS & Removed all \texttt{\textbackslash wss\{\}} comments from the MIS \\
-\bottomrule
+  \toprule
+  \textbf{Item} & \textbf{Source}  & \textbf{Feedback}                                                                       & \textbf{Response}                                                 \\
+  \midrule
+  \endhead
+  MG-1          & TA (Issue~\#164) & Typo: ``relys''                                                                         & Corrected to ``relies on''                                        \\
+  \midrule
+  MG-2          & TA (Issue~\#164) & Typo: ``Stablize''                                                                      & Corrected to ``Stabilize''                                        \\
+  \midrule
+  MG-3          & TA (Issue~\#164) & Residual \texttt{\textbackslash wss\{\}} template comments remained in the Module Guide & Removed all \texttt{\textbackslash wss\{\}} comments from the MG  \\
+  \midrule
+  MIS-1         & TA (Issue~\#240) & Incorrect year: ``Jan 2025'' should be ``Jan 2026''                                     & Corrected to ``Jan 2026''                                         \\
+  \midrule
+  MIS-2         & TA (Issue~\#240) & Typo: ``presistent''                                                                    & Corrected to ``persistent''                                       \\
+  \midrule
+  MIS-3         & TA (Issue~\#240) & Residual \texttt{\textbackslash wss\{\}} template comments remained in the MIS          & Removed all \texttt{\textbackslash wss\{\}} comments from the MIS \\
+  \bottomrule
 \end{longtable}
 
 \subsection{VnV Plan and Report}
@@ -116,64 +116,64 @@ Changes were made in commits \texttt{30cd72c} and \texttt{45a7df6} (PR~\#365).
 \subsubsection{VnV Plan}
 
 \begin{longtable}{p{0.08\textwidth} p{0.20\textwidth} p{0.32\textwidth} p{0.32\textwidth}}
-\toprule
-\textbf{Item} & \textbf{Source} & \textbf{Feedback} & \textbf{Response} \\
-\midrule
-\endhead
-VP-1 & TA (Issue~\#122) & Residual \texttt{\textbackslash wss\{\}} template comments in VnV Plan & Removed all \texttt{\textbackslash wss\{\}} comments \\
-\midrule
-VP-2 & TA (Issue~\#122) & No unit test summary section & Added a dedicated unit test summary section listing all unit tests and their status \\
-\midrule
-VP-3 & TA (Issue~\#122) & Grammar: ``a outline'' & Corrected to ``an outline'' \\
-\midrule
-VP-4 & TA (Issue~\#337) & Test-tracking details were insufficient & Enhanced test-tracking details with specific pass/fail criteria and expected timelines \\
-\midrule
-VP-5 & Issue~\#148 & Error-handling tests lacked timing specifications & Added timing constraints to error-handling tests (e.g., error detection within 200\,ms) \\
-\bottomrule
+  \toprule
+  \textbf{Item} & \textbf{Source}  & \textbf{Feedback}                                                      & \textbf{Response}                                                                       \\
+  \midrule
+  \endhead
+  VP-1          & TA (Issue~\#122) & Residual \texttt{\textbackslash wss\{\}} template comments in VnV Plan & Removed all \texttt{\textbackslash wss\{\}} comments                                    \\
+  \midrule
+  VP-2          & TA (Issue~\#122) & No unit test summary section                                           & Added a dedicated unit test summary section listing all unit tests and their status     \\
+  \midrule
+  VP-3          & TA (Issue~\#122) & Grammar: ``a outline''                                                 & Corrected to ``an outline''                                                             \\
+  \midrule
+  VP-4          & TA (Issue~\#337) & Test-tracking details were insufficient                                & Enhanced test-tracking details with specific pass/fail criteria and expected timelines  \\
+  \midrule
+  VP-5          & Issue~\#148      & Error-handling tests lacked timing specifications                      & Added timing constraints to error-handling tests (e.g., error detection within 200\,ms) \\
+  \bottomrule
 \end{longtable}
 
 \subsubsection{VnV Report}
 
 \begin{longtable}{p{0.08\textwidth} p{0.20\textwidth} p{0.32\textwidth} p{0.32\textwidth}}
-\toprule
-\textbf{Item} & \textbf{Source} & \textbf{Feedback} & \textbf{Response} \\
-\midrule
-\endhead
-VR-1 & Peer (Issue~\#346) & Green ``Pass'' text is not distinguishable for colour-blind users & Changed green ``Pass'' indicators to teal (WCAG~AA compliant, $\geq$4.5:1 contrast ratio) \\
-\midrule
-VR-2 & TA (Issue~\#337) & VnV Report scope was unclear & Added explicit scope clarification at the beginning of the report \\
-\midrule
-VR-3 & Peer (Issue~\#348) & No discussion of planned future improvements & Added a ``Planned Future Improvements'' section \\
-\midrule
-VR-4 & Peer (Issue~\#344) & Duplicate descriptions between VnV Plan and VnV Report & Condensed overlapping descriptions and added cross-references to the VnV Plan \\
-\bottomrule
+  \toprule
+  \textbf{Item} & \textbf{Source}    & \textbf{Feedback}                                                 & \textbf{Response}                                                                         \\
+  \midrule
+  \endhead
+  VR-1          & Peer (Issue~\#346) & Green ``Pass'' text is not distinguishable for colour-blind users & Changed green ``Pass'' indicators to teal (WCAG~AA compliant, $\geq$4.5:1 contrast ratio) \\
+  \midrule
+  VR-2          & TA (Issue~\#337)   & VnV Report scope was unclear                                      & Added explicit scope clarification at the beginning of the report                         \\
+  \midrule
+  VR-3          & Peer (Issue~\#348) & No discussion of planned future improvements                      & Added a ``Planned Future Improvements'' section                                           \\
+  \midrule
+  VR-4          & Peer (Issue~\#344) & Duplicate descriptions between VnV Plan and VnV Report            & Condensed overlapping descriptions and added cross-references to the VnV Plan             \\
+  \bottomrule
 \end{longtable}
 
 \subsubsection{Peer Review Responses}
 
 \begin{longtable}{p{0.08\textwidth} p{0.32\textwidth} p{0.52\textwidth}}
-\toprule
-\textbf{Issue} & \textbf{Feedback} & \textbf{Response} \\
-\midrule
-\endhead
-\#342 & Usability testing should be included & Out of scope for this deliverable; usability was addressed through iterative client demos and informal user testing with the McMaster Rocketry Team. Explained in issue. \\
-\midrule
-\#343 & Table formatting issues in VnV Report & Already fixed prior to peer review being filed; confirmed and closed the issue \\
-\midrule
-\#344 & Duplicate test descriptions between Plan and Report & Condensed duplicated content and replaced with cross-references to the VnV Plan \\
-\midrule
-\#345 & Hardware testing scope was unclear & Added clarification that hardware-specific tests (e.g., motor stress tests) are outside the scope of the software VnV \\
-\midrule
-\#346 & Green text for ``Pass'' is inaccessible & Changed to teal with a contrast ratio $\geq$4.5:1 for WCAG~AA compliance \\
-\midrule
-\#347 & Some tests lacked sufficient detail & Enhanced test descriptions with explicit inputs, expected outputs, and pass/fail criteria \\
-\midrule
-\#348 & No section on future improvements & Added ``Planned Future Improvements'' section covering field testing, expanded model training, and weatherproofing \\
-\midrule
-\#148 & Error-handling tests lacked timing information & Added specific timing thresholds (e.g., error detection within 200\,ms, recovery within 1\,s) \\
-\midrule
-\#149 & Field testing not covered in VnV & Explicitly noted that field testing is out of scope for the current VnV cycle; listed as a planned future improvement \\
-\bottomrule
+  \toprule
+  \textbf{Issue} & \textbf{Feedback}                                   & \textbf{Response}                                                                                                                                                        \\
+  \midrule
+  \endhead
+  \#342          & Usability testing should be included                & Out of scope for this deliverable; usability was addressed through iterative client demos and informal user testing with the McMaster Rocketry Team. Explained in issue. \\
+  \midrule
+  \#343          & Table formatting issues in VnV Report               & Already fixed prior to peer review being filed; confirmed and closed the issue                                                                                           \\
+  \midrule
+  \#344          & Duplicate test descriptions between Plan and Report & Condensed duplicated content and replaced with cross-references to the VnV Plan                                                                                          \\
+  \midrule
+  \#345          & Hardware testing scope was unclear                  & Added clarification that hardware-specific tests (e.g., motor stress tests) are outside the scope of the software VnV                                                    \\
+  \midrule
+  \#346          & Green text for ``Pass'' is inaccessible             & Changed to teal with a contrast ratio $\geq$4.5:1 for WCAG~AA compliance                                                                                                 \\
+  \midrule
+  \#347          & Some tests lacked sufficient detail                 & Enhanced test descriptions with explicit inputs, expected outputs, and pass/fail criteria                                                                                \\
+  \midrule
+  \#348          & No section on future improvements                   & Added ``Planned Future Improvements'' section covering field testing, expanded model training, and weatherproofing                                                       \\
+  \midrule
+  \#148          & Error-handling tests lacked timing information      & Added specific timing thresholds (e.g., error detection within 200\,ms, recovery within 1\,s)                                                                            \\
+  \midrule
+  \#149          & Field testing not covered in VnV                    & Explicitly noted that field testing is out of scope for the current VnV cycle; listed as a planned future improvement                                                    \\
+  \bottomrule
 \end{longtable}
 
 \section{Extras}
@@ -183,27 +183,27 @@ were approved by the course instructor in our problem statement.
 
 \begin{itemize}
   \item \textbf{Circuit Design Report}: Documents the design and verification of
-    a custom STM32-based printed circuit board (PCB) for gimbal motor control.
-    The PCB interfaces with the Jetson Orin Nano via UART and provides precise
-    two-axis servo control with encoder feedback. The report includes schematic
-    design, component selection rationale, PCB layout considerations, and
-    hardware testing results. Located in
-    \texttt{docs/Extras/CircuitDesign/}.
+        a custom STM32-based printed circuit board (PCB) for gimbal motor control.
+        The PCB interfaces with the Jetson Orin Nano via UART and provides precise
+        two-axis servo control with encoder feedback. The report includes schematic
+        design, component selection rationale, PCB layout considerations, and
+        hardware testing results. Located in
+        \texttt{docs/Extras/CircuitDesign/}.
 
   \item \textbf{Machine Learning Report}: Documents the YOLO-based object
-    detection model training pipeline used for rocket detection and tracking.
-    The report covers dataset preparation, model architecture selection,
-    training methodology, TensorRT optimization for deployment on the Jetson
-    Orin Nano, and benchmark results comparing inference speed and accuracy
-    across different optimization levels. Located in
-    \texttt{docs/Extras/MachineLearning/}.
+        detection model training pipeline used for rocket detection and tracking.
+        The report covers dataset preparation, model architecture selection,
+        training methodology, TensorRT optimization for deployment on the Jetson
+        Orin Nano, and benchmark results comparing inference speed and accuracy
+        across different optimization levels. Located in
+        \texttt{docs/Extras/MachineLearning/}.
 \end{itemize}
 
 \section{Design Iteration (LO11 (PrototypeIterate))}
 
-The design of RoCam evolved substantially over the course of the project through
-multiple iterations driven by feedback from our supervisor, client, and peer
-reviewers.
+The design of RoCam evolved substantially over the course of the project
+through multiple iterations driven by feedback from our supervisor, client, and
+peer reviewers.
 
 \textbf{Rev~0 (January 2026):} The initial design established the core module
 decomposition (M1--M21) covering computer vision, livestream management,
@@ -224,32 +224,31 @@ safety risk if the control loop failed.
 \textbf{Rev~1 (April 2026):} Incorporating all feedback, Rev~1 introduced
 several key improvements:
 \begin{itemize}
-  \item Added SR4 (Emergency Stop) with both hardware and software triggers,
-    including a physical kill switch and a software-initiated stop command
-    accessible from the UI.
-  \item Created a full HA~$\leftrightarrow$~SRS traceability matrix ensuring
-    every identified hazard maps to at least one safety requirement and vice
-    versa.
+  \item Added SR4 (Emergency Stop) with both hardware and software triggers, including
+        a physical kill switch and a software-initiated stop command accessible from
+        the UI.
+  \item Created a full HA~$\leftrightarrow$~SRS traceability matrix ensuring every
+        identified hazard maps to at least one safety requirement and vice versa.
   \item Expanded test coverage with a dedicated unit test summary and enhanced
-    integration test specifications.
-  \item Adopted process separation---running CV inference, livestream encoding,
-    and transcoding as independent worker processes---to achieve the target of
-    1080p at 60\,fps with less than 120\,ms end-to-end latency.
+        integration test specifications.
+  \item Adopted process separation---running CV inference, livestream encoding, and
+        transcoding as independent worker processes---to achieve the target of 1080p at
+        60\,fps with less than 120\,ms end-to-end latency.
 \end{itemize}
 
 \textbf{Client-driven iteration:} The McMaster Rocketry Team provided hands-on
 feedback during iterative demos that shaped several user-facing features:
 \begin{itemize}
   \item \textbf{Drag-to-move gimbal control}: The client requested an intuitive
-    way to manually aim the camera when automatic tracking was not engaged. We
-    implemented a click-and-drag interface on the video feed that translates
-    mouse movements into gimbal angle commands.
+        way to manually aim the camera when automatic tracking was not engaged. We
+        implemented a click-and-drag interface on the video feed that translates
+        mouse movements into gimbal angle commands.
   \item \textbf{Bilingual UI}: To accommodate team members more comfortable in
-    French, we added English/French language toggle support.
+        French, we added English/French language toggle support.
   \item \textbf{Confirmation prompts}: After an incident where a team member
-    accidentally reset the gimbal during a demo, we added confirmation dialogs
-    for all potentially dangerous operations (e.g., gimbal reset, firmware
-    flash).
+        accidentally reset the gimbal during a demo, we added confirmation dialogs
+        for all potentially dangerous operations (e.g., gimbal reset, firmware
+        flash).
 \end{itemize}
 
 \textbf{Hardware iteration:} Mid-project, the originally selected camera sensor
@@ -269,74 +268,74 @@ and constraints specific to the RoCam project.
 
 \begin{itemize}
   \item \textbf{Budget constraint (500\,CAD)}: The total hardware budget of
-    500\,CAD eliminated commercial tracking systems (typically \$5{,}000+) and
-    constrained our platform choice. The Jetson Orin Nano was selected because it
-    offers GPU-accelerated inference in a compact, power-efficient form factor
-    within our budget. This limitation also drove the decision to design a custom
-    PCB for gimbal control rather than purchasing an expensive commercial servo
-    controller.
+        500\,CAD eliminated commercial tracking systems (typically \$5{,}000+) and
+        constrained our platform choice. The Jetson Orin Nano was selected because it
+        offers GPU-accelerated inference in a compact, power-efficient form factor
+        within our budget. This limitation also drove the decision to design a custom
+        PCB for gimbal control rather than purchasing an expensive commercial servo
+        controller.
 
   \item \textbf{Power and thermal constraints}: The system must operate outdoors
-    in a field environment powered by a portable battery. This ruled out
-    high-power server-grade GPUs and motivated our investment in TensorRT
-    optimization, which reduced inference power consumption by approximately 40\%
-    compared to running the YOLO model without optimization.
+        in a field environment powered by a portable battery. This ruled out
+        high-power server-grade GPUs and motivated our investment in TensorRT
+        optimization, which reduced inference power consumption by approximately 40\%
+        compared to running the YOLO model without optimization.
 
   \item \textbf{Network availability}: Launch sites often lack reliable internet
-    connectivity. This drove the decision to run all processing on-device (edge
-    computing) rather than offloading to cloud services, and to use a local
-    Wi-Fi access point for the operator interface.
+        connectivity. This drove the decision to run all processing on-device (edge
+        computing) rather than offloading to cloud services, and to use a local
+        Wi-Fi access point for the operator interface.
 \end{itemize}
 
 \subsection*{Assumptions}
 
 \begin{itemize}
   \item \textbf{Jetson as deployment platform}: We assumed early in the project
-    that the Jetson Orin Nano would be the final deployment platform. This
-    assumption guided our investment in TensorRT optimization and CUDA-based
-    GStreamer pipelines. The assumption was validated through benchmarking,
-    which confirmed that the Jetson could achieve the required inference speed
-    ($\leq$15\,ms per frame) with TensorRT.
+        that the Jetson Orin Nano would be the final deployment platform. This
+        assumption guided our investment in TensorRT optimization and CUDA-based
+        GStreamer pipelines. The assumption was validated through benchmarking,
+        which confirmed that the Jetson could achieve the required inference speed
+        ($\leq$15\,ms per frame) with TensorRT.
 
   \item \textbf{Single-rocket tracking}: We assumed the system would track one
-    rocket at a time, simplifying the detection pipeline to single-object
-    tracking after initial detection. This assumption aligned with the client's
-    use case.
+        rocket at a time, simplifying the detection pipeline to single-object
+        tracking after initial detection. This assumption aligned with the client's
+        use case.
 
   \item \textbf{Operator presence}: We assumed a human operator would always be
-    present to initiate tracking and intervene if needed, which justified the
-    semi-automatic design rather than a fully autonomous system.
+        present to initiate tracking and intervene if needed, which justified the
+        semi-automatic design rather than a fully autonomous system.
 \end{itemize}
 
 \subsection*{Constraints and Key Decisions}
 
 \begin{itemize}
   \item \textbf{Process separation (CV, Livestream, Transcode)}: The real-time
-    performance requirement (1080p at 60\,fps with $<$120\,ms latency) could not
-    be met with a single-process architecture. We separated the CV inference,
-    livestream encoding, and transcoding into independent worker processes
-    communicating via shared memory and IPC. This decision was driven entirely by
-    measured performance bottlenecks during Rev~0 testing.
+        performance requirement (1080p at 60\,fps with $<$120\,ms latency) could not
+        be met with a single-process architecture. We separated the CV inference,
+        livestream encoding, and transcoding into independent worker processes
+        communicating via shared memory and IPC. This decision was driven entirely by
+        measured performance bottlenecks during Rev~0 testing.
 
   \item \textbf{Flask + Server-Sent Events (SSE) over WebSocket}: For the
-    communication between backend and frontend, we chose Flask with SSE rather
-    than WebSocket. SSE is simpler to implement and sufficient for our use case,
-    which requires only unidirectional status updates from server to client.
-    Bidirectional commands (e.g., gimbal control) are handled via standard HTTP
-    POST requests. This decision reduced implementation complexity without
-    sacrificing functionality.
+        communication between backend and frontend, we chose Flask with SSE rather
+        than WebSocket. SSE is simpler to implement and sufficient for our use case,
+        which requires only unidirectional status updates from server to client.
+        Bidirectional commands (e.g., gimbal control) are handled via standard HTTP
+        POST requests. This decision reduced implementation complexity without
+        sacrificing functionality.
 
   \item \textbf{Custom PCB over off-the-shelf servo controller}: The gimbal
-    requires precise two-axis control with real-time encoder feedback at rates
-    that commodity servo controllers could not reliably provide. The custom
-    STM32-based PCB allowed us to implement a tuned PID control loop with
-    direct encoder integration, achieving smoother and more responsive gimbal
-    movement.
+        requires precise two-axis control with real-time encoder feedback at rates
+        that commodity servo controllers could not reliably provide. The custom
+        STM32-based PCB allowed us to implement a tuned PID control loop with
+        direct encoder integration, achieving smoother and more responsive gimbal
+        movement.
 
   \item \textbf{React/TypeScript frontend}: We chose React with TypeScript for
-    the operator interface to enable a responsive single-page application that
-    works well on tablets in outdoor settings. TypeScript provided type safety
-    that caught several integration bugs at compile time.
+        the operator interface to enable a responsive single-page application that
+        works well on tablets in outdoor settings. TypeScript provided type safety
+        that caught several integration bugs at compile time.
 \end{itemize}
 
 \section{Economic Considerations (LO23)}
@@ -367,10 +366,8 @@ would be most effective. By releasing the software under the MIT license, we can
 attract contributors, build community trust, and generate organic adoption. Revenue
 could be generated through:
 \begin{itemize}
-  \item Selling pre-assembled hardware kits for users who prefer not to build
-    their own
-  \item Offering premium support and custom integration services for university
-    teams
+  \item Selling pre-assembled hardware kits for users who prefer not to build their own
+  \item Offering premium support and custom integration services for university teams
   \item Partnering with rocketry suppliers for distribution
 \end{itemize}
 
@@ -379,72 +376,73 @@ could be generated through:
 \subsection{How Does Your Project Management Compare to Your Development Plan}
 
 We largely followed our Development Plan as written. Weekly team meetings were
-held consistently, with agendas and minutes tracked via GitHub Issues. Asynchronous
-communication was conducted on Discord, and bi-weekly meetings with our
-supervisor, Dr.~Sirouspour, were held over Zoom. Team member roles aligned with
-the plan: Zifan Si led frontend development, Jianqing Liu handled backend
-architecture and served as team lead, Mike Chen was responsible for the computer
-vision pipeline, and Xiaotian Lou managed hardware integration and PCB design.
+held consistently, with agendas and minutes tracked via GitHub Issues.
+Asynchronous communication was conducted on Discord, and bi-weekly meetings
+with our supervisor, Dr.~Sirouspour, were held over Zoom. Team member roles
+aligned with the plan: Zifan Si led frontend development, Jianqing Liu handled
+backend architecture and served as team lead, Mike Chen was responsible for the
+computer vision pipeline, and Xiaotian Lou managed hardware integration and PCB
+design.
 
 We used GitHub Projects for task tracking, with a Kanban-style board organized
 by sprint. All code changes went through pull request review before merging,
-which was consistent with our planned workflow. The technology stack matched our
-plan: Python for the backend (Flask), React/TypeScript for the frontend, YOLO
-with TensorRT for computer vision, and an STM32-based custom PCB for gimbal
-control, all deployed on the Jetson Orin Nano.
+which was consistent with our planned workflow. The technology stack matched
+our plan: Python for the backend (Flask), React/TypeScript for the frontend,
+YOLO with TensorRT for computer vision, and an STM32-based custom PCB for
+gimbal control, all deployed on the Jetson Orin Nano.
 
 \subsection{What Went Well?}
 
 \begin{itemize}
   \item \textbf{CI/CD pipeline}: Our GitHub Actions setup for automated linting
-    and testing caught issues early and maintained code quality throughout the
-    project. Every pull request was required to pass CI checks before merging.
+        and testing caught issues early and maintained code quality throughout the
+        project. Every pull request was required to pass CI checks before merging.
   \item \textbf{Structured sprint process}: Two-week sprints with clear
-    deliverables kept the team on track and made progress visible to all
-    stakeholders.
+        deliverables kept the team on track and made progress visible to all
+        stakeholders.
   \item \textbf{PR-based code review}: Requiring at least one approving review
-    before merging improved code quality and knowledge sharing across team
-    members. Several bugs were caught during review that would have been
-    difficult to debug later.
+        before merging improved code quality and knowledge sharing across team
+        members. Several bugs were caught during review that would have been
+        difficult to debug later.
   \item \textbf{Issue-driven feedback tracking}: Using GitHub Issues to track
-    all feedback items made it straightforward to ensure every piece of feedback
-    was addressed and traceable.
+        all feedback items made it straightforward to ensure every piece of feedback
+        was addressed and traceable.
 \end{itemize}
 
 \subsection{What Went Wrong?}
 
 \begin{itemize}
   \item \textbf{Camera sensor change}: The mid-project switch to a different
-    camera sensor required significant rework of the CAD model, updated
-    calibration parameters, and revised latency measurements. This consumed
-    approximately two weeks of effort that had not been planned for.
+        camera sensor required significant rework of the CAD model, updated
+        calibration parameters, and revised latency measurements. This consumed
+        approximately two weeks of effort that had not been planned for.
   \item \textbf{Integration complexity underestimated}: Integrating the custom
-    PCB with the Jetson, the CV pipeline with the livestream, and the frontend
-    with the backend all proved more complex than anticipated. Serial
-    communication timing issues between the STM32 and Jetson required
-    substantial debugging effort.
+        PCB with the Jetson, the CV pipeline with the livestream, and the frontend
+        with the backend all proved more complex than anticipated. Serial
+        communication timing issues between the STM32 and Jetson required
+        substantial debugging effort.
   \item \textbf{Limited field testing}: Due to weather constraints and schedule
-    pressure, we were unable to conduct as many outdoor field tests as we had
-    planned. Most testing was done in controlled indoor environments.
+        pressure, we were unable to conduct as many outdoor field tests as we had
+        planned. Most testing was done in controlled indoor environments.
 \end{itemize}
 
 \subsection{What Would you Do Differently Next Time?}
 
 \begin{itemize}
   \item \textbf{Start hardware integration earlier}: We would begin
-    hardware-software integration testing in the first month rather than waiting
-    until the individual components were more mature. Early integration would
-    have surfaced the serial communication issues sooner.
+        hardware-software integration testing in the first month rather than waiting
+        until the individual components were more mature. Early integration would
+        have surfaced the serial communication issues sooner.
   \item \textbf{Allocate more time for field testing}: We would schedule regular
-    outdoor testing sessions starting from Rev~0, rather than treating field
-    testing as a final validation step.
+        outdoor testing sessions starting from Rev~0, rather than treating field
+        testing as a final validation step.
   \item \textbf{Component sourcing contingency}: We would identify backup
-    components for critical hardware (especially sensors) at the outset of the
-    project to reduce the impact of mid-project changes.
+        components for critical hardware (especially sensors) at the outset of the
+        project to reduce the impact of mid-project changes.
   \item \textbf{Documentation-as-you-go}: While our documentation was ultimately
-    comprehensive, several documents required significant last-minute updates.
-    Maintaining documents in parallel with development would distribute the
-    workload more evenly.
+        comprehensive, several documents required significant last-minute updates.
+        Maintaining documents in parallel with development would distribute the
+        workload more evenly.
 \end{itemize}
 
 \section{Ethics and Equity (LO18)}
@@ -454,64 +452,64 @@ project to ensure the system is accessible and fair to all stakeholders.
 
 \begin{itemize}
   \item \textbf{Bilingual user interface}: The operator interface supports both
-    English and French, reflecting Canada's official bilingualism and ensuring
-    accessibility for team members and users who are more comfortable in either
-    language.
+        English and French, reflecting Canada's official bilingualism and ensuring
+        accessibility for team members and users who are more comfortable in either
+        language.
 
   \item \textbf{Colour-blind safe indicators}: After peer feedback
-    (Issue~\#346) identified that green ``Pass'' indicators were not
-    distinguishable for users with red-green colour vision deficiency, we
-    replaced all green status indicators with teal, achieving a contrast ratio
-    of at least 4.5:1 (WCAG~AA compliance). All status information is also
-    conveyed through text labels, not colour alone.
+        (Issue~\#346) identified that green ``Pass'' indicators were not
+        distinguishable for users with red-green colour vision deficiency, we
+        replaced all green status indicators with teal, achieving a contrast ratio
+        of at least 4.5:1 (WCAG~AA compliance). All status information is also
+        conveyed through text labels, not colour alone.
 
   \item \textbf{Outdoor-readable single-page UI}: The interface was designed as
-    a single-page application with large, high-contrast elements optimized for
-    use on tablets in bright outdoor conditions. This design decision ensures
-    usability for operators who may be wearing sunglasses or gloves.
+        a single-page application with large, high-contrast elements optimized for
+        use on tablets in bright outdoor conditions. This design decision ensures
+        usability for operators who may be wearing sunglasses or gloves.
 
   \item \textbf{Confirmation prompts for dangerous actions}: To prevent
-    accidental harm---particularly relevant given the gimbal's mechanical
-    movement---all potentially dangerous operations (gimbal reset, firmware
-    flash, emergency stop override) require explicit confirmation. This
-    protects both the operator and bystanders.
+        accidental harm---particularly relevant given the gimbal's mechanical
+        movement---all potentially dangerous operations (gimbal reset, firmware
+        flash, emergency stop override) require explicit confirmation. This
+        protects both the operator and bystanders.
 
   \item \textbf{Open-source licensing}: The project is released under the MIT
-    license, ensuring equitable access to the technology regardless of
-    institutional affiliation or budget. Any rocketry team, hobbyist, or
-    researcher can use, modify, and redistribute the system at no cost.
+        license, ensuring equitable access to the technology regardless of
+        institutional affiliation or budget. Any rocketry team, hobbyist, or
+        researcher can use, modify, and redistribute the system at no cost.
 
   \item \textbf{Privacy considerations}: The system is designed for tracking
-    rockets, not people. We intentionally trained the YOLO model exclusively on
-    rocket imagery and did not include any person-detection capabilities. The
-    system operates on a local network with no cloud data transmission,
-    minimizing privacy risks for bystanders at launch events.
+        rockets, not people. We intentionally trained the YOLO model exclusively on
+        rocket imagery and did not include any person-detection capabilities. The
+        system operates on a local network with no cloud data transmission,
+        minimizing privacy risks for bystanders at launch events.
 \end{itemize}
 
 \section{Reflection on Capstone}
 
 \subsection{Which Courses Were Relevant}
 
-Several courses from our undergraduate curriculum provided foundational knowledge
-that was directly applicable to the RoCam project:
+Several courses from our undergraduate curriculum provided foundational
+knowledge that was directly applicable to the RoCam project:
 
 \begin{itemize}
   \item \textbf{SFWRENG 3K04 -- Software Design III}: This course provided the
-    foundation for our modular software architecture, including the use of
-    design patterns and the module decomposition reflected in our Module Guide.
+        foundation for our modular software architecture, including the use of
+        design patterns and the module decomposition reflected in our Module Guide.
 
   \item \textbf{SFWRENG 2C03 -- Data Structures and Algorithms}: Knowledge of
-    efficient data structures was essential for the real-time tracking pipeline,
-    particularly for managing detection queues and frame buffers.
+        efficient data structures was essential for the real-time tracking pipeline,
+        particularly for managing detection queues and frame buffers.
 
   \item \textbf{SFWRENG 3DX4 -- Signals and Systems}: Understanding of signal
-    processing concepts was directly applicable to the GStreamer video pipeline
-    design and the PID control loop for gimbal stabilization.
+        processing concepts was directly applicable to the GStreamer video pipeline
+        design and the PID control loop for gimbal stabilization.
 
   \item \textbf{CAS 741 -- Development of Scientific Computing Software}:
-    This graduate-level course informed our approach to rigorous documentation,
-    including the SRS, MG, MIS, and VnV Plan/Report structure used throughout
-    the project.
+        This graduate-level course informed our approach to rigorous documentation,
+        including the SRS, MG, MIS, and VnV Plan/Report structure used throughout
+        the project.
 \end{itemize}
 
 \subsection{Knowledge/Skills Outside of Courses}
@@ -521,34 +519,34 @@ were not covered in our coursework:
 
 \begin{itemize}
   \item \textbf{TensorRT optimization}: None of our courses covered
-    NVIDIA's TensorRT framework. We learned to convert YOLO models to TensorRT
-    engines, perform INT8 calibration, and benchmark inference performance on
-    the Jetson Orin Nano.
+        NVIDIA's TensorRT framework. We learned to convert YOLO models to TensorRT
+        engines, perform INT8 calibration, and benchmark inference performance on
+        the Jetson Orin Nano.
 
   \item \textbf{GStreamer pipelines}: Building low-latency video encoding and
-    decoding pipelines using GStreamer with hardware-accelerated codecs required
-    substantial self-directed learning, as no course covered multimedia
-    framework programming.
+        decoding pipelines using GStreamer with hardware-accelerated codecs required
+        substantial self-directed learning, as no course covered multimedia
+        framework programming.
 
   \item \textbf{PCB design}: Designing the custom STM32-based PCB required
-    learning schematic capture, PCB layout, design rule checking, and
-    manufacturing processes (Xiaotian). This included learning KiCad and
-    understanding EMI/EMC considerations for motor control circuits.
+        learning schematic capture, PCB layout, design rule checking, and
+        manufacturing processes (Xiaotian). This included learning KiCad and
+        understanding EMI/EMC considerations for motor control circuits.
 
   \item \textbf{Real-time systems programming}: While courses touched on
-    concurrency, the practical challenges of building a real-time system with
-    strict latency requirements ($<$120\,ms end-to-end) required learning about
-    process isolation, shared memory IPC, and Linux real-time scheduling.
+        concurrency, the practical challenges of building a real-time system with
+        strict latency requirements ($<$120\,ms end-to-end) required learning about
+        process isolation, shared memory IPC, and Linux real-time scheduling.
 
   \item \textbf{React and TypeScript frontend development}: The frontend was
-    built with React and TypeScript, neither of which was covered in our
-    curriculum. We learned component-based UI architecture, state management,
-    and responsive design for the operator interface.
+        built with React and TypeScript, neither of which was covered in our
+        curriculum. We learned component-based UI architecture, state management,
+        and responsive design for the operator interface.
 
   \item \textbf{Embedded firmware development}: Writing firmware for the STM32
-    microcontroller, including UART communication protocols and PID motor
-    control, required learning the STM32 HAL library and embedded C programming
-    practices.
+        microcontroller, including UART communication protocols and PID motor
+        control, required learning the STM32 HAL library and embedded C programming
+        practices.
 \end{itemize}
 
 \end{document}


### PR DESCRIPTION
## Summary
Fill all sections of `docs/ReflectAndTrace/ReflectAndTrace.tex`:
- **Feedback traceability tables**: Every feedback item from TA Tanya (#107, #122, #164, #240, #337), peer reviews (#342-#348, #148, #149), and supervisor mapped to specific changes with commit references
- **Extras summary**: Circuit Design Report + ML Report
- **LO reflections**: Design Iteration (LO11), Design Decisions (LO12), Economic Considerations (LO23), Project Management (LO24), Ethics & Equity (LO18), Capstone Reflection

## Rubric Target
**Update SRS & HA, Design Docs, VnV (6/6 each):** "The changes are clearly and completely documented. Traceability between change and reason for the change."

## Test plan
- [ ] Verify no `\plt{` template markers remain
- [ ] Verify feedback tables reference commits (30cd72c, 45a7df6)
- [ ] Verify all LO sections have substantive content
- [ ] Compile LaTeX successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)